### PR TITLE
Add Outline to the default list of excluded filetypes

### DIFF
--- a/lua/sunglasses/defaults.lua
+++ b/lua/sunglasses/defaults.lua
@@ -32,6 +32,7 @@ local defaults = {
         "registers",
         "startuptime",
         "OverseerList",
+        "Outline",
         "Navbuddy",
         "noice",
         "notify",


### PR DESCRIPTION
[outline.nvim](https://github.com/hedyhli/outline.nvim) is a plugin to show the symbol outline for the current file. It's often used as an inactive window so it makes sense to exclude it by default.