### PR TITLE
fix: prevent 'Key not found' error when checking for shaded window

### DIFF
--- a/lua/sunglasses/window.lua
+++ b/lua/sunglasses/window.lua
@@ -100,7 +100,8 @@ function Window:config(window_options)
 end
 
 function Window:is_shaded()
-    return vim.api.nvim_win_get_var(self.window, 'Sunglasses')
+    local ok, _ = pcall(vim.api.nvim_win_get_var, self.window, 'Sunglasses')
+    return ok
 end
 
 function Window:can_shade()


### PR DESCRIPTION
I was playing around with https://github.com/stevearc/quicker.nvim and noticed this error happened (probably because quicker.nvim was lazy loaded)

```
BufEnter Autocommands for "*": Vim(append):Error executing lua callback: ...b.com/yujinyuz/sunglasses.nvim/lua/sunglasses/win
dow.lua:166: Key not found: Sunglasses
```