### PR TITLE
fix: use result of nvim_win_get_var instead of pcall status

### DIFF
--- a/lua/sunglasses/window.lua
+++ b/lua/sunglasses/window.lua
@@ -100,8 +100,8 @@ function Window:config(window_options)
 end
 
 function Window:is_shaded()
-    local ok, _ = pcall(vim.api.nvim_win_get_var, self.window, 'Sunglasses')
-    return ok
+    local _, result = pcall(vim.api.nvim_win_get_var, self.window, 'Sunglasses')
+    return result
 end
 
 function Window:can_shade()


### PR DESCRIPTION
Made a mistake from my previous PR

https://github.com/miversen33/sunglasses.nvim/pull/23

since it returns the success status instead of the result of the variable.

I just noticed awhile ago that windows aren't being shaded anymore.

Apologies for breaking this